### PR TITLE
Feature/template project list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,9 @@ cython_debug/
 
 /tools/node_modules
 /.vscode
+example.json
+_ExampleView.py
+
 
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can

--- a/hakusai/templates/hakusai/base.html
+++ b/hakusai/templates/hakusai/base.html
@@ -10,7 +10,10 @@
     <!-- <link href="{% static 'hakusai/css/style.min.css' %}" rel="stylesheet"> -->
 </head>
 
-<body class="h-full w-full">
+{% block additional %}
+{% endblock %}
+
+<body class="h-full w-full bg-green-50">
     {% block content %}
     {% endblock %}
 </body>

--- a/hakusai/templates/hakusai/base.html
+++ b/hakusai/templates/hakusai/base.html
@@ -2,7 +2,8 @@
 
 <html lang="ja" class="h-full w-full">
 
-<head>
+    
+    <head>
     <meta charset="UTF-8" />
     <title>Hakusai | {% block title %}{% endblock %}</title>
     <script src="https://cdn.tailwindcss.com"></script>
@@ -13,3 +14,5 @@
     {% block content %}
     {% endblock %}
 </body>
+
+</html>

--- a/hakusai/templates/hakusai/base.html
+++ b/hakusai/templates/hakusai/base.html
@@ -1,6 +1,6 @@
 {% load static %}
 
-<html lang="ja" class="h-full">
+<html lang="ja" class="h-full w-full">
 
 <head>
     <meta charset="UTF-8" />
@@ -9,7 +9,7 @@
     <!-- <link href="{% static 'hakusai/css/style.min.css' %}" rel="stylesheet"> -->
 </head>
 
-<body class="h-full">
+<body class="h-full w-full">
     {% block content %}
     {% endblock %}
 </body>

--- a/hakusai/templates/hakusai/base_with_header.html
+++ b/hakusai/templates/hakusai/base_with_header.html
@@ -1,16 +1,7 @@
-{% load static %}
+{% extends 'hakusai/base.html' %}
 
-<html lang="ja" class="h-full w-full">
-
-<head>
-    <meta charset="UTF-8" />
-    <title>Hakusai | {% block title %}{% endblock %}</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <!-- <link href="{% static 'hakusai/css/style.min.css' %}" rel="stylesheet"> -->
-</head>
-
-<body class="h-full w-full bg-green-50">
-    <!-- ヘッダー -->
+{% block additional %}
+<!-- ヘッダー -->
     <div class="flex space-x-6 items-center justify-start h-40 mx-20 sticky top-0 z-50 bg-green-50">
         <!-- ヘッダーアイコン -->
         {% block content_header_icon %}{% endblock %}
@@ -24,6 +15,7 @@
         {% block content_header_item %}{% endblock %}
     </div>
 
+{% endblock %}
     <!-- ページコンテンツ -->
     {% block content %}{% endblock %}
 </body>

--- a/hakusai/templates/hakusai/base_with_header.html
+++ b/hakusai/templates/hakusai/base_with_header.html
@@ -1,0 +1,29 @@
+{% load static %}
+
+<html lang="ja" class="h-full w-full">
+
+<head>
+    <meta charset="UTF-8" />
+    <title>Hakusai | {% block title %}{% endblock %}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <!-- <link href="{% static 'hakusai/css/style.min.css' %}" rel="stylesheet"> -->
+</head>
+
+<body class="h-full w-full bg-green-50">
+    <!-- ヘッダー -->
+    <div class="flex space-x-6 items-center justify-start h-40 mx-20 sticky top-0 z-50 bg-green-50">
+        <!-- ヘッダーアイコン -->
+        {% block content_header_icon %}{% endblock %}
+
+        <!-- ヘッダータイトル -->
+        <p class="w-60 text-2xl leading-10 text-gray-600">
+            {% with content_header_title=title %}{{ content_header_title }}{% endwith %}
+        </p>
+
+        <!-- ヘッダー要素(ボタン等) -->
+        {% block content_header_item %}{% endblock %}
+    </div>
+
+    <!-- ページコンテンツ -->
+    {% block content %}{% endblock %}
+</body>

--- a/hakusai/templates/hakusai/project_list.html
+++ b/hakusai/templates/hakusai/project_list.html
@@ -1,9 +1,39 @@
-{% extends 'hakusai/base.html' %}
+{% extends 'hakusai/base_with_header.html' %}
 {% load static %}
 
-{% block title %} TOP {% endblock %}
+{% block title %} {{ title }} {% endblock %}
+
+{% block content_header_icon %} 
+<svg class="w-10 h-10 rounded-lg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
+    <path d="M19.5 21a3 3 0 003-3v-4.5a3 3 0 00-3-3h-15a3 3 0 00-3 3V18a3 3 0 003 3h15zM1.5 10.146V6a3 3 0 013-3h5.379a2.25 2.25 0 011.59.659l2.122 2.121c.14.141.331.22.53.22H19.5a3 3 0 013 3v1.146A4.483 4.483 0 0019.5 9h-15a4.483 4.483 0 00-3 1.146z" />
+</svg>
+{% endblock %}
+
+{% block content_header_item %}
+    <a class="px-4 py-2 text-lg text-center text-gray-100 bg-blue-500 shadow rounded-2xl hover:opacity-80"
+        href="{% url 'hakusai:project_new_summary' %}">
+        新規作成
+    </a> 
+{% endblock %}
 
 {% block content %}
-
-
+<div class="w-3/4 m-auto">
+    <div class="grid grid-cols-1 gap-2">
+        {% for project in projects %}
+        <a class="col-span-1 flex flex-col space-y-3 items-start p-5 bg-gray-50 border rounded-2xl border-gray-400 hover:opacity-80"
+            href="{% url 'hakusai:project_edit' project_id=project.id %}">
+            
+            <div class="flex space-x-3">
+                <p class="text-xl text-gray-700">{{ project.title }}</p>
+                {% if project.draft_flag %}
+                <div class="bg-gray-400"><p class="w-full px-2 py-1 text-center text-gray-50">下書き</p></div>
+                {% endif %}
+            </div>
+            
+            <p class="text-lg text-center text-gray-600">{{ project.url }}</p>
+        </a>
+        {% endfor %}
+    
+    </div>
+</div>
 {% endblock %}

--- a/hakusai/templates/hakusai/project_list.html
+++ b/hakusai/templates/hakusai/project_list.html
@@ -1,5 +1,4 @@
 {% extends 'hakusai/base_with_header.html' %}
-{% load static %}
 
 {% block title %} {{ title }} {% endblock %}
 

--- a/hakusai/views/ProjectListViewClass.py
+++ b/hakusai/views/ProjectListViewClass.py
@@ -1,5 +1,10 @@
+from typing import Any, Dict
 from django.views.generic import TemplateView
-
 
 class ProjectListView(TemplateView):
     template_name = 'hakusai/project_list.html'
+
+    def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        context['title'] = 'プロジェクト一覧'
+        return context


### PR DESCRIPTION
## 実装内容(簡潔にでOK)
- baseの修正
- project一覧のTemplate実装


## 連絡事項・補足事項
- これに当てはまる形でcontextをviewから渡してください
titleを渡しているところがあるので、それの受け渡し処理を真似してprojectsを渡してください。
使っているのは21行の {% for project in projects %} からです。
draft_flagのみboolean型でDBから正しく渡せるか確認できていないので困ったら聞いてくださいー
また、都合でidやtitleといった名前は変えてもらってもokです

- 今は何も渡されていないので以下のように表示されているはずなので、同じ表示が確認出来たらokで
![image](https://github.com/Tatsuyyy/hakusai/assets/64631535/026ac2a1-253f-471c-b0c0-d511865c6110) 
